### PR TITLE
feat: 상품 목록 페이지 마크업 구현

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,14 @@
 @import 'tailwindcss';
 
 @theme {
-  --color-primary: #4ac5b2;
-  --color-secondary: #e89a80;
-  --color-white: #f8f7f4;
-  --color-black: #1a1c20;
+  --color-yg-primary: #4ac5b2;
+  --color-yg-secondary: #e89a80;
+  --color-yg-white: #f8f7f4;
+  --color-yg-black: #1a1c20;
+  --color-yg-gray: #b7b7b7;
+  --color-yg-lightgray: #d9d9d9;
+  --color-yg-darkgray: #757575;
+  --color-yg-warning: #f52525;
 }
 
 @layer base {

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,0 +1,131 @@
+// app/products/page.tsx
+'use client';
+
+import { useMemo, useState, useEffect } from 'react';
+import CategoryTabs from '@/components/products/CategoryTabs';
+import ProductGrid from '@/components/products/ProductGrid';
+import ProductListSkeleton from '@/components/products/ProductListSkeleton';
+import EmptyState from '@/components/products/EmptyState';
+import ErrorState from '@/components/products/ErrorState';
+import { getProducts } from '@/lib/api/products';
+import type { Category, SupplementItem, SortType } from '@/types/product';
+
+export default function ProductsPage() {
+  const categories: Category[] = useMemo(
+    () => [
+      { id: 'all', name: '전체' },
+      { id: 'diet', name: '다이어트' },
+      { id: 'eye', name: '눈건강' },
+      { id: 'gut', name: '장건강' },
+      { id: 'immune', name: '면역' },
+      { id: 'skin', name: '피부' },
+    ],
+    []
+  );
+
+  const [selectedCategoryId, setSelectedCategoryId] = useState('all');
+  const [sort, setSort] = useState<SortType>('popular');
+
+  // ✅ 원본 데이터(서버에서 받은 전체 목록)
+  const [allProducts, setAllProducts] = useState<SupplementItem[]>([]);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [retryKey, setRetryKey] = useState(0);
+
+  // ✅ API 호출: 이제 category/sort 의존성 제거 (서버가 지원 안 하니까)
+  useEffect(() => {
+    let alive = true;
+
+    async function fetchProducts() {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const res = await getProducts();
+
+        if (!alive) return;
+
+        if (res.ok === 1) {
+          setAllProducts(res.data ?? []);
+        } else {
+          setAllProducts([]);
+          setError(res.message ?? '상품을 불러오는데 실패했습니다.');
+        }
+      } catch (err: unknown) {
+        if (!alive) return;
+        setAllProducts([]);
+        setError(err instanceof Error ? err.message : '상품을 불러오는데 실패했습니다.');
+      } finally {
+        if (!alive) return;
+        setIsLoading(false);
+      }
+    }
+
+    fetchProducts();
+
+    return () => {
+      alive = false;
+    };
+  }, [retryKey]);
+
+  const handleRetry = () => setRetryKey((k) => k + 1);
+
+  // ✅ 프론트에서 필터/정렬 처리
+  const products = useMemo(() => {
+    // 1) 카테고리 필터
+    const filtered = selectedCategoryId === 'all' ? allProducts : allProducts.filter((p) => p.categoryId === selectedCategoryId);
+
+    // 2) 정렬
+    const sorted = [...filtered];
+    if (sort === 'priceLow') sorted.sort((a, b) => a.price - b.price);
+    if (sort === 'priceHigh') sorted.sort((a, b) => b.price - a.price);
+    // popular: 서버 지원 없으니 일단 원본 순서 유지(또는 id 기준 등으로 임시 정렬 가능)
+
+    return sorted;
+  }, [allProducts, selectedCategoryId, sort]);
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-8">
+      <header className="mb-6 text-center">
+        <h1 className="text-lg font-semibold tracking-tight text-yg-black">상품 리스트</h1>
+      </header>
+
+      <section className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <CategoryTabs categories={categories} selectedId={selectedCategoryId} onSelect={setSelectedCategoryId} />
+
+        <div className="flex items-center justify-end gap-2">
+          <label className="text-xs text-yg-darkgray" htmlFor="sort">
+            정렬
+          </label>
+          <select id="sort" value={sort} onChange={(e) => setSort(e.target.value as SortType)} className="h-9 rounded-lg border border-yg-lightgray bg-white px-3 text-sm" aria-label="상품 정렬 방식 선택">
+            <option value="popular">인기순</option>
+            <option value="priceLow">가격 낮은순</option>
+            <option value="priceHigh">가격 높은순</option>
+          </select>
+        </div>
+      </section>
+
+      <section className="min-h-[50vh]">
+        {isLoading && <ProductListSkeleton />}
+
+        {!isLoading && error && <ErrorState title="상품을 불러오지 못했어요." description={error} onRetry={handleRetry} />}
+
+        {!isLoading && !error && products.length === 0 && <EmptyState title="상품이 없어요." description="다른 카테고리를 선택해보세요." />}
+
+        {!isLoading && !error && products.length > 0 && <ProductGrid items={products} renderLink={(id) => `/products/${id}`} />}
+      </section>
+
+      <footer className="mt-10 flex items-center justify-center gap-2">
+        <button type="button" className="h-9 rounded-lg border border-yg-lightgray px-3 text-sm disabled:opacity-50" disabled>
+          이전
+        </button>
+        <span className="text-sm text-yg-darkgray">1 / 10</span>
+        <button type="button" className="h-9 rounded-lg border border-yg-lightgray px-3 text-sm disabled:opacity-50" disabled>
+          다음
+        </button>
+      </footer>
+    </main>
+  );
+}

--- a/components/products/CategoryTabs.tsx
+++ b/components/products/CategoryTabs.tsx
@@ -1,0 +1,29 @@
+// components/products/CategoryTabs.tsx
+'use client';
+
+import type { Category } from '@/types/product';
+
+type Props = {
+  categories: Category[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+};
+
+/**
+ * [CategoryTabs]
+ * - 카테고리 탭 UI (가로 스크롤)
+ */
+export default function CategoryTabs({ categories, selectedId, onSelect }: Props) {
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2" aria-label="상품 카테고리">
+      {categories.map((c) => {
+        const active = c.id === selectedId;
+        return (
+          <button key={c.id} type="button" aria-pressed={active} onClick={() => onSelect(c.id)} className={`shrink-0 rounded-full border px-4 py-2 text-sm transition ${active ? 'border-yg-primary bg-yg-primary text-white' : 'border-yg-lightgray bg-white text-yg-darkgray hover:bg-yg-white'}`}>
+            {c.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/products/EmptyState.tsx
+++ b/components/products/EmptyState.tsx
@@ -1,0 +1,21 @@
+// components/products/EmptyState.tsx
+type Props = {
+  title: string;
+  description?: string;
+};
+
+/**
+ * [EmptyState]
+ * - 목록이 비었을 때 표시
+ */
+export default function EmptyState({ title, description }: Props) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center text-center">
+      <div className="mb-4 text-6xl" aria-hidden="true">
+        📦
+      </div>
+      <h2 className="mb-2 text-lg font-semibold text-yg-black">{title}</h2>
+      {description && <p className="text-sm text-yg-darkgray">{description}</p>}
+    </div>
+  );
+}

--- a/components/products/ErrorState.tsx
+++ b/components/products/ErrorState.tsx
@@ -1,0 +1,27 @@
+// components/products/ErrorState.tsx
+type Props = {
+  title: string;
+  description?: string;
+  onRetry?: () => void;
+};
+
+/**
+ * [ErrorState]
+ * - API 실패 등 에러 상태 표시
+ */
+export default function ErrorState({ title, description, onRetry }: Props) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center text-center">
+      <div className="mb-4 text-6xl" aria-hidden="true">
+        ⚠️
+      </div>
+      <h2 className="mb-2 text-lg font-semibold text-yg-black">{title}</h2>
+      {description && <p className="mb-4 text-sm text-yg-darkgray">{description}</p>}
+      {onRetry && (
+        <button type="button" onClick={onRetry} className="rounded-lg bg-yg-black px-4 py-2 text-sm text-white transition hover:opacity-90">
+          다시 시도
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/products/ProductCard.tsx
+++ b/components/products/ProductCard.tsx
@@ -1,0 +1,51 @@
+// components/products/ProductCard.tsx
+import Link from 'next/link';
+import type { SupplementItem } from '@/types/product';
+
+type Props = {
+  item: SupplementItem;
+  href: string;
+};
+
+function formatPrice(price: number) {
+  return new Intl.NumberFormat('ko-KR').format(price);
+}
+
+/**
+ * [ProductCard]
+ * - 상품 1개 카드(Item)
+ */
+export default function ProductCard({ item, href }: Props) {
+  const badges: string[] = item.mainNutrients?.slice(0, 2) ?? [];
+
+  return (
+    <Link href={href} className="rounded-3xl bg-yg-white p-5 shadow-xl transition hover:-translate-y-0.5 hover:shadow-2xl" aria-label={`${item.name} 상품 상세보기`}>
+      <div className="aspect-square w-full rounded-2xl bg-yg-lightgray" aria-hidden="true" />
+
+      <div className="mt-5">
+        <h3 className="text-xl font-extrabold text-yg-black">{item.name}</h3>
+        <p className="mt-1 text-sm text-yg-darkgray">상품 캡션</p>
+
+        {badges.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {badges.map((badge) => (
+              <span key={badge} className="rounded-full bg-yg-primary px-3 py-1 text-xs text-white">
+                {badge}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-5 flex items-end justify-between">
+          <p className="text-sm text-yg-darkgray">
+            월 <span className="text-3xl font-extrabold text-yg-black">{formatPrice(item.price)}</span>원
+          </p>
+
+          <div className="text-yg-secondary" aria-label="별점">
+            ★★★★★
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/components/products/ProductGrid.tsx
+++ b/components/products/ProductGrid.tsx
@@ -1,0 +1,22 @@
+// components/products/ProductGrid.tsx
+import ProductCard from './ProductCard';
+import type { SupplementItem } from '@/types/product';
+
+type Props = {
+  items: SupplementItem[];
+  renderLink?: (id: SupplementItem['_id']) => string;
+};
+
+/**
+ * [ProductGrid]
+ * - 카드 그리드 레이아웃
+ */
+export default function ProductGrid({ items, renderLink }: Props) {
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((item) => (
+        <ProductCard key={item._id} item={item} href={renderLink ? renderLink(item._id) : `/products/${item._id}`} />
+      ))}
+    </div>
+  );
+}

--- a/components/products/ProductListSkeleton.tsx
+++ b/components/products/ProductListSkeleton.tsx
@@ -1,0 +1,21 @@
+// components/products/ProductListSkeleton.tsx
+/**
+ * [ProductListSkeleton]
+ * - 목록 로딩 상태 스켈레톤
+ */
+export default function ProductListSkeleton() {
+  return (
+    <div aria-busy="true" aria-live="polite" className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <div key={idx} className="rounded-3xl bg-yg-white p-5 shadow-xl">
+          <div className="aspect-square w-full animate-pulse rounded-2xl bg-yg-lightgray" />
+          <div className="mt-5 space-y-3">
+            <div className="h-6 w-2/3 animate-pulse rounded bg-yg-lightgray" />
+            <div className="h-4 w-1/2 animate-pulse rounded bg-yg-lightgray" />
+            <div className="h-6 w-1/3 animate-pulse rounded bg-yg-lightgray" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/api/products.ts
+++ b/lib/api/products.ts
@@ -1,0 +1,51 @@
+// lib/api/product.ts
+import type { SupplementItem } from '@/types/product';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID || '';
+
+export type ApiResponse<T> = {
+  ok: 1 | 0;
+  data?: T;
+  message?: string;
+};
+
+function assertEnv(): { apiUrl: string; clientId: string } {
+  if (!API_URL) throw new Error('NEXT_PUBLIC_API_URL 환경 변수가 없습니다.');
+  if (!CLIENT_ID) throw new Error('NEXT_PUBLIC_CLIENT_ID 환경 변수가 없습니다.');
+  return { apiUrl: API_URL, clientId: CLIENT_ID };
+}
+
+function normalizeListResponse(json: unknown): ApiResponse<SupplementItem[]> {
+  const j = json as any;
+  const list: unknown = j?.data ?? j?.items ?? j?.item ?? j?.list ?? [];
+
+  if (j?.ok === 1 && Array.isArray(list)) return { ok: 1, data: list as SupplementItem[] };
+  return { ok: 0, data: [], message: j?.message ?? '상품 목록 조회 실패' };
+}
+
+export async function getProducts(): Promise<ApiResponse<SupplementItem[]>> {
+  try {
+    const { apiUrl, clientId } = assertEnv();
+
+    const url = `${apiUrl}/products`;
+
+    const response = await fetch(url, {
+      headers: { 'Client-Id': clientId },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      return { ok: 0, data: [], message: `HTTP error! status: ${response.status}` };
+    }
+
+    const json = (await response.json()) as unknown;
+    return normalizeListResponse(json);
+  } catch (err: unknown) {
+    return {
+      ok: 0,
+      data: [],
+      message: err instanceof Error ? err.message : '상품 목록 조회 실패',
+    };
+  }
+}

--- a/types/product.ts
+++ b/types/product.ts
@@ -1,0 +1,32 @@
+// types/product.ts
+
+export type Category = {
+  id: string;
+  name: string;
+};
+
+export type NutritionNutrient = {
+  name: string;
+  amount?: string;
+  percent?: string;
+};
+
+export type NutritionInfoExample = {
+  servingSize: string;
+  nutrients: NutritionNutrient[];
+};
+
+export type SupplementItem = {
+  _id: string;
+  price: number;
+  name: string;
+  categoryId: string;
+  mainNutrients: string[];
+  mainFunctions: string[];
+  intakeGuide: string;
+  precautions: string[];
+  storage: string;
+  nutritionInfoExample?: NutritionInfoExample;
+};
+
+export type SortType = 'popular' | 'priceLow' | 'priceHigh';


### PR DESCRIPTION
## 연관 이슈

- #4 

## 반영 브랜치

- feature/#4-product-list-markup -> develop

## 작업 사항

- [x] 상품 목록 페이지 레이아웃 구성 (헤더/컨테이너/그리드)
- [x] 카테고리 탭 UI 마크업 구현
 - [x] 가로 스크롤 지원
 - [x] 선택 상태 스타일 처리
- [x] 상품 카드 컴포넌트(ProductCard) 마크업 구현
 - [x] 이미지 영역
 - [x] 상품 / 가격 정보 표시
- [x] 상품 리스트 컴포넌트 (ProductGrid / List ) 구성
 - [x] 데이터 map 기반 렌더링 구조
- [x] 로딩 상태 스켈레톤 UI 마크업 추가
- [x] 빈 결과 (상품 없음) 상태 UI 마크업 추가
- [x] 에러 상태 UI 마크업 추가
 - [x] 재시도 버튼 포함

## 전달 사항
- 카테고리/ 정렬 로직은 API 스펙에 맞춰 처리했습니다.
- 디자인은 추후 더 다듬어 볼 예정입니다.
