### PR TITLE
feature: 샹품 상세페이지 마크업

### DIFF
--- a/app/products/[_id]/error.tsx
+++ b/app/products/[_id]/error.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export default function Error() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <p className="text-yg-warning font-semibold">상품 정보를 불러오는 중 오류가 발생했습니다.</p>
+    </div>
+  );
+}

--- a/app/products/[_id]/loading.tsx
+++ b/app/products/[_id]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <div className="h-40 rounded-lg bg-yg-lightgray animate-pulse" />
+    </div>
+  );
+}

--- a/app/products/[_id]/page.tsx
+++ b/app/products/[_id]/page.tsx
@@ -1,0 +1,54 @@
+import { productDetailMock } from '@/mock/productDetail.mock';
+
+export default function ProductDetailPage() {
+  const product = productDetailMock;
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-8">
+      {/* 상단 타이틀 (확인용) */}
+      <h1 className="mb-6 text-2xl font-bold text-yg-black">{product.name}</h1>
+
+      {/* 전체 레이아웃 */}
+      <section className="grid grid-cols-12 gap-6">
+        {/* 좌측 영역 */}
+        <div className="col-span-8 space-y-6">
+          {/* 상품 요약 영역 */}
+          <div className="rounded-lg bg-yg-white p-6 shadow">
+            <p className="text-sm text-yg-darkgray">상품 요약 영역</p>
+            <p className="mt-2 text-lg font-semibold">{product.summary}</p>
+          </div>
+
+          {/* 탭 영역 */}
+          <div className="rounded-lg bg-yg-white p-4 shadow">
+            <p className="text-sm text-yg-darkgray">탭 UI 영역</p>
+            <div className="mt-3 flex gap-4">
+              <button className="font-semibold text-yg-primary">주요 기능</button>
+              <button className="text-yg-gray">영양 정보</button>
+              <button className="text-yg-gray">섭취 방법</button>
+              <button className="text-yg-gray">주의사항</button>
+            </div>
+          </div>
+
+          {/* 상세 섹션 영역 */}
+          <div className="rounded-lg bg-yg-white p-6 shadow">
+            <p className="mb-2 text-sm text-yg-darkgray">상세 정보 섹션 영역</p>
+            <ul className="list-disc pl-5 text-yg-black">
+              {product.features.map((item, idx) => (
+                <li key={idx}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {/* 우측 구매 카드 영역 */}
+        <aside className="col-span-4">
+          <div className="sticky top-20 rounded-lg bg-yg-white p-6 shadow">
+            <p className="text-sm text-yg-darkgray">구매 카드 영역</p>
+            <p className="mt-2 text-xl font-bold text-yg-black">{product.price.toLocaleString()}원</p>
+            <button className="mt-4 w-full rounded-md bg-yg-primary py-3 text-white">구매하기</button>
+          </div>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/mock/productDetail.mock.ts
+++ b/mock/productDetail.mock.ts
@@ -1,0 +1,7 @@
+export const productDetailMock = {
+  id: '1',
+  name: '비타민C 1000',
+  summary: '고함량 비타민C로 면역력 증진에 도움',
+  price: 19900,
+  features: ['항산화 작용', '면역력 강화', '피로 회복 도움'],
+};


### PR DESCRIPTION
## 연관 이슈

- #12 

## 반영 브랜치

- feature-샹품-상세-페이지-마크업 -> develop

## 작업 사항

- [x] 라우트 생성 : `products/[_id]`
- [x] 페이지 레이아웃 (컨테이너/그리드) 마크업
- [x] mockData 연결 (하드코딩 1개 예시)
- [x] 상태 UI 자리 (loadind/empty/error) 박스만 생성

## 전달 사항
mock 데이터는 현재 마크업 상태를 보기 위해 하드코딩으로 정보를 넣어둔 상태입니다.
데이터 넣는 작업 시작 시 추후 삭제 예정입니다.