### PR TITLE
feat: ProductSummary 컴포넌트 분리 및 마크업 추가

### DIFF
--- a/app/products/[_id]/page.tsx
+++ b/app/products/[_id]/page.tsx
@@ -1,3 +1,4 @@
+import ProductSummary from '@/components/products/ProductSummary';
 import { productDetailMock } from '@/mock/productDetail.mock';
 
 export default function ProductDetailPage() {
@@ -13,11 +14,7 @@ export default function ProductDetailPage() {
         {/* 좌측 영역 */}
         <div className="col-span-8 space-y-6">
           {/* 상품 요약 영역 */}
-          <div className="rounded-lg bg-yg-white p-6 shadow">
-            <p className="text-sm text-yg-darkgray">상품 요약 영역</p>
-            <p className="mt-2 text-lg font-semibold">{product.summary}</p>
-          </div>
-
+          <ProductSummary name={product.name} summary={product.summary} price={product.price} brand={product.brand} rating={product.rating} reviewCount={product.reviewCount} shippingLabel={product.shippingLabel} imageUrl={product.imageUrl} tags={product.tags} />
           {/* 탭 영역 */}
           <div className="rounded-lg bg-yg-white p-4 shadow">
             <p className="text-sm text-yg-darkgray">탭 UI 영역</p>

--- a/components/products/ProductSummary.tsx
+++ b/components/products/ProductSummary.tsx
@@ -1,0 +1,76 @@
+type ProductSummaryProps = {
+  name: string;
+  summary: string;
+  price: number;
+  brand?: string;
+  rating?: number;
+  reviewCount?: number;
+  shippingLabel?: string;
+  imageUrl?: string;
+  tags?: string[];
+};
+
+export default function ProductSummary({ name, summary, price, brand, rating, reviewCount, shippingLabel, imageUrl, tags }: ProductSummaryProps) {
+  return (
+    <section className="rounded-lg bg-yg-white p-6 shadow">
+      <div className="grid grid-cols-12 gap-6">
+        {/* 이미지 영역 */}
+        <div className="col-span-5">
+          <div className="aspect-square w-full overflow-hidden rounded-lg bg-yg-lightgray">
+            {/* next/image 붙이기 전까지는 img로 */}
+            {imageUrl ? <img src={imageUrl} alt={name} className="h-full w-full object-cover" /> : <div className="flex h-full w-full items-center justify-center text-yg-darkgray">이미지 없음</div>}
+          </div>
+
+          {/* 썸네일(선택) 자리 */}
+          <div className="mt-3 flex gap-2">
+            <div className="h-14 w-14 rounded-md bg-yg-lightgray" />
+            <div className="h-14 w-14 rounded-md bg-yg-lightgray" />
+            <div className="h-14 w-14 rounded-md bg-yg-lightgray" />
+          </div>
+        </div>
+
+        {/* 텍스트/버튼 영역 */}
+        <div className="col-span-7 flex flex-col">
+          {/* 태그/브랜드 */}
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            {tags?.map((t) => (
+              <span key={t} className="rounded-full bg-yg-secondary px-2 py-1 text-xs font-semibold text-yg-black">
+                {t}
+              </span>
+            ))}
+            {brand && <span className="text-sm font-medium text-yg-darkgray">{brand}</span>}
+          </div>
+
+          {/* 상품명 */}
+          <h1 className="text-2xl font-bold text-yg-black">{name}</h1>
+
+          {/* 요약 */}
+          <p className="mt-2 text-sm leading-6 text-yg-darkgray">{summary}</p>
+
+          {/* 평점/리뷰 */}
+          {(rating || reviewCount) && (
+            <div className="mt-3 flex items-center gap-2 text-sm">
+              {rating !== undefined && <span className="font-semibold text-yg-black">★ {rating}</span>}
+              {reviewCount !== undefined && <span className="text-yg-darkgray">리뷰 {reviewCount.toLocaleString()}</span>}
+            </div>
+          )}
+
+          {/* 가격 */}
+          <div className="mt-4">
+            <p className="text-sm text-yg-darkgray">판매가</p>
+            <p className="text-3xl font-extrabold text-yg-black">{price.toLocaleString()}원</p>
+          </div>
+
+          {/* 배송 */}
+          {shippingLabel && <p className="mt-2 text-sm text-yg-darkgray">{shippingLabel}</p>}
+
+          {/* 버튼 */}
+          <div className="mt-auto flex gap-3 pt-6">
+            <button className="flex-1 rounded-md bg-yg-primary py-3 font-semibold text-white">구매하기</button>
+            <button className="flex-1 rounded-md border border-yg-lightgray bg-white py-3 font-semibold text-yg-black">장바구니</button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/mock/productDetail.mock.ts
+++ b/mock/productDetail.mock.ts
@@ -3,5 +3,11 @@ export const productDetailMock = {
   name: '비타민C 1000',
   summary: '고함량 비타민C로 면역력 증진에 도움',
   price: 19900,
+  brand: 'YOUNGGOO',
+  rating: 4.8,
+  reviewCount: 124,
+  shippingLabel: '무료배송 · 2~3일 내 도착',
+  imageUrl: '/images/sample-product.png', // 일단 퍼블릭에 샘플 넣거나 임시 경로
+  tags: ['BEST', '인기'],
   features: ['항산화 작용', '면역력 강화', '피로 회복 도움'],
 };


### PR DESCRIPTION
## 연관 이슈

- #16 
## 반영 브랜치

- feature-productsummary -> develop

## 작업 사항

- [x] `PruductSummary` 컴포넌트 생성
- [x] 상품 이미지 영역 마크업
- [x] 상품명 / 요약 설명 마크업
- [x] 가격 정보 표시
- [x] 배송 정보 UI
- [x] 구매하기 및 장바구니 버튼 마크업 (이 부분은 아직 예정인 부분)
- [x] Tailwind + yg 컬러 토큰 적용
