### PR TITLE
feature: ProductInfoTabs 컴포넌트 마크업

### DIFF
--- a/app/products/[_id]/page.tsx
+++ b/app/products/[_id]/page.tsx
@@ -1,3 +1,4 @@
+import ProductInfoTabs from '@/components/products/ProductInfoTabs';
 import ProductSummary from '@/components/products/ProductSummary';
 import { productDetailMock } from '@/mock/productDetail.mock';
 
@@ -16,16 +17,7 @@ export default function ProductDetailPage() {
           {/* 상품 요약 영역 */}
           <ProductSummary name={product.name} summary={product.summary} price={product.price} brand={product.brand} rating={product.rating} reviewCount={product.reviewCount} shippingLabel={product.shippingLabel} imageUrl={product.imageUrl} tags={product.tags} />
           {/* 탭 영역 */}
-          <div className="rounded-lg bg-yg-white p-4 shadow">
-            <p className="text-sm text-yg-darkgray">탭 UI 영역</p>
-            <div className="mt-3 flex gap-4">
-              <button className="font-semibold text-yg-primary">주요 기능</button>
-              <button className="text-yg-gray">영양 정보</button>
-              <button className="text-yg-gray">섭취 방법</button>
-              <button className="text-yg-gray">주의사항</button>
-            </div>
-          </div>
-
+          <ProductInfoTabs active="features" />
           {/* 상세 섹션 영역 */}
           <div className="rounded-lg bg-yg-white p-6 shadow">
             <p className="mb-2 text-sm text-yg-darkgray">상세 정보 섹션 영역</p>

--- a/components/products/ProductInfoTabs.tsx
+++ b/components/products/ProductInfoTabs.tsx
@@ -1,0 +1,36 @@
+type TabKey = 'features' | 'nutrition' | 'intake' | 'cautions';
+
+type ProductInfoTabsProps = {
+  active?: TabKey; // 지금은 고정용(기본값 features)
+};
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'features', label: '주요 기능' },
+  { key: 'nutrition', label: '영양 정보' },
+  { key: 'intake', label: '섭취 방법' },
+  { key: 'cautions', label: '주의사항' },
+];
+
+export default function ProductInfoTabs({ active = 'features' }: ProductInfoTabsProps) {
+  return (
+    <nav aria-label="상품 상세 탭" className="rounded-lg bg-yg-white px-6 pt-4 shadow">
+      <div className="flex gap-6 border-b border-yg-lightgray">
+        {TABS.map((tab) => {
+          const isActive = tab.key === active;
+
+          return (
+            <button key={tab.key} type="button" className={['relative pb-3 text-sm font-semibold transition', isActive ? 'text-yg-primary' : 'text-yg-gray hover:text-yg-darkgray'].join(' ')}>
+              {tab.label}
+
+              {/* active underline */}
+              {isActive && <span className="absolute left-0 right-0 -bottom-[1px] h-[3px] rounded-full bg-yg-primary" />}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 아래 여백 (시안 느낌 맞추기) */}
+      <div className="h-3" />
+    </nav>
+  );
+}


### PR DESCRIPTION
## 연관 이슈

- #22 

## 반영 브랜치

- feature/product-detail-tabs -> develop (예제 삭제)

## 작업 사항

- [x] `ProductInfoTabs` 컴포넌트 생성
- [x] 탭 4개 마크업 (주요기능/ 영양 정보/ 섭취방법/ 주의사항)
- [x] active 탭 스타일 적용 (고정)
- [x] `page.tsx` 에서 컴포넌트 사용하도록 교체
- [x] tailwind + yg 컬러 토큰 적용

