### PR TITLE
feat: 우측 구매 카드 컴포넌트 분리

### DIFF
--- a/app/products/[_id]/page.tsx
+++ b/app/products/[_id]/page.tsx
@@ -1,3 +1,4 @@
+import ProductSidePurchaseCard from '@/components/products/ProductSidePurchaseCard';
 import ProductInfoSection from '@/components/products/ProductInfoSection';
 import ProductInfoTabs from '@/components/products/ProductInfoTabs';
 import ProductSummary from '@/components/products/ProductSummary';
@@ -24,13 +25,7 @@ export default function ProductDetailPage() {
         </div>
 
         {/* 우측 구매 카드 영역 */}
-        <aside className="col-span-4">
-          <div className="sticky top-20 rounded-lg bg-yg-white p-6 shadow">
-            <p className="text-sm text-yg-darkgray">구매 카드 영역</p>
-            <p className="mt-2 text-xl font-bold text-yg-black">{product.price.toLocaleString()}원</p>
-            <button className="mt-4 w-full rounded-md bg-yg-primary py-3 text-white">구매하기</button>
-          </div>
-        </aside>
+        <ProductSidePurchaseCard price={product.price} shippingLabel={product.shippingLabel} />
       </section>
     </main>
   );

--- a/components/products/ProductSidePurchaseCard.tsx
+++ b/components/products/ProductSidePurchaseCard.tsx
@@ -1,0 +1,23 @@
+type ProductSidePurchaseCardProps = {
+  price: number;
+  shippingLabel?: string;
+};
+
+export default function ProductSidePurchaseCard({ price, shippingLabel }: ProductSidePurchaseCardProps) {
+  return (
+    <aside className="col-span-4">
+      <div className="sticky top-20 rounded-lg bg-yg-white p-6 shadow">
+        <p className="text-sm text-yg-darkgray">구매 정보</p>
+
+        <p className="mt-3 text-2xl font-extrabold text-yg-black">{price.toLocaleString()}원</p>
+
+        {shippingLabel && <p className="mt-2 text-sm text-yg-darkgray">{shippingLabel}</p>}
+
+        <div className="mt-5 space-y-3">
+          <button className="w-full rounded-md bg-yg-primary py-3 font-semibold text-white">구매하기</button>
+          <button className="w-full rounded-md border border-yg-lightgray bg-white py-3 font-semibold text-yg-black">장바구니</button>
+        </div>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## 연관 이슈

- #27 

## 반영 브랜치

- feature/product-detail-side-card -> develop (예제 삭제)

## 작업 사항

- [x] `ProductSidePurchaseCard` 컴포넌트 생성
- [x] 가격/ 배송정보 / 버튼 마크업 (배송 정보는 고려 사항)
- [x] Stiky 레이아웃 유지
- [x] `pase/tsx` 에서 기존 aside 마크업 제거 후 컴포넌트로 교체
- [x] Tailwind + yg 컬러 토큰 적용

## 전달 사항 
- 좀 있어보이고 싶었어요..의견 받아요..ㅎㅎ