### PR TITLE
feat: 상품 상세 탭 클릭 로직 및 스크롤 이동 추가

### DIFF
--- a/app/products/[_id]/page.tsx
+++ b/app/products/[_id]/page.tsx
@@ -1,30 +1,42 @@
+'use client';
+
+import { useState } from 'react';
 import ProductSidePurchaseCard from '@/components/products/ProductSidePurchaseCard';
 import ProductInfoSection from '@/components/products/ProductInfoSection';
 import ProductInfoTabs from '@/components/products/ProductInfoTabs';
 import ProductSummary from '@/components/products/ProductSummary';
 import { productDetailMock } from '@/mock/productDetail.mock';
 
+type TabKey = 'features' | 'nutrition' | 'intake' | 'cautions';
+
 export default function ProductDetailPage() {
   const product = productDetailMock;
 
+  const [activeTab, setActiveTab] = useState<TabKey>('features');
+
+  const handleChangeTab = (key: TabKey) => {
+    setActiveTab(key);
+
+    const el = document.getElementById(key);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
   return (
     <main className="mx-auto max-w-7xl px-4 py-8">
-      {/* 상단 타이틀 (확인용) */}
       <h1 className="mb-6 text-2xl font-bold text-yg-black">{product.name}</h1>
 
-      {/* 전체 레이아웃 */}
       <section className="grid grid-cols-12 gap-6">
-        {/* 좌측 영역 */}
         <div className="col-span-8 space-y-6">
-          {/* 상품 요약 영역 */}
           <ProductSummary name={product.name} summary={product.summary} price={product.price} brand={product.brand} rating={product.rating} reviewCount={product.reviewCount} shippingLabel={product.shippingLabel} imageUrl={product.imageUrl} tags={product.tags} />
-          {/* 탭 영역 */}
-          <ProductInfoTabs active="features" />
-          {/* 상세 섹션 영역 */}
+
+          {/* ✅ 탭 클릭 로직 연결 */}
+          <ProductInfoTabs active={activeTab} onChange={handleChangeTab} />
+
           <ProductInfoSection features={product.features} nutritionFacts={product.nutritionFacts} intake={product.intake} cautions={product.cautions} />
         </div>
 
-        {/* 우측 구매 카드 영역 */}
         <ProductSidePurchaseCard price={product.price} shippingLabel={product.shippingLabel} />
       </section>
     </main>

--- a/components/products/ProductInfoSection.tsx
+++ b/components/products/ProductInfoSection.tsx
@@ -15,7 +15,7 @@ export default function ProductInfoSection({ features, nutritionFacts, intake, c
   return (
     <section className="space-y-10">
       {/* 주요 기능 */}
-      <div className="rounded-lg bg-yg-white p-6 shadow">
+      <div id="features" className="rounded-lg bg-yg-white p-6 shadow">
         <h2 className="mb-4 text-lg font-bold text-yg-black">주요 기능</h2>
         <ul className="list-disc space-y-2 pl-5 text-yg-black">
           {features.map((item, idx) => (
@@ -25,7 +25,7 @@ export default function ProductInfoSection({ features, nutritionFacts, intake, c
       </div>
 
       {/* 영양 정보 */}
-      <div className="rounded-lg bg-yg-white p-6 shadow">
+      <div id="nutrition" className="rounded-lg bg-yg-white p-6 shadow">
         <h2 className="mb-4 text-lg font-bold text-yg-black">영양 정보</h2>
         <table className="w-full border-collapse text-sm">
           <thead>
@@ -48,13 +48,13 @@ export default function ProductInfoSection({ features, nutritionFacts, intake, c
       </div>
 
       {/* 섭취 방법 */}
-      <div className="rounded-lg bg-yg-white p-6 shadow">
+      <div id="intake" className="rounded-lg bg-yg-white p-6 shadow">
         <h2 className="mb-3 text-lg font-bold text-yg-black">섭취 방법</h2>
         <p className="text-yg-black">{intake}</p>
       </div>
 
       {/* 주의사항 */}
-      <div className="rounded-lg border border-yg-warning bg-white p-6">
+      <div id="cautions" className="rounded-lg border border-yg-warning bg-white p-6">
         <h2 className="mb-3 text-lg font-bold text-yg-warning">주의사항</h2>
         <ul className="list-disc space-y-2 pl-5 text-yg-black">
           {cautions.map((item, idx) => (

--- a/components/products/ProductInfoTabs.tsx
+++ b/components/products/ProductInfoTabs.tsx
@@ -1,7 +1,8 @@
 type TabKey = 'features' | 'nutrition' | 'intake' | 'cautions';
 
 type ProductInfoTabsProps = {
-  active?: TabKey; // 지금은 고정용(기본값 features)
+  active: TabKey;
+  onChange: (key: TabKey) => void;
 };
 
 const TABS: { key: TabKey; label: string }[] = [
@@ -11,7 +12,7 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: 'cautions', label: '주의사항' },
 ];
 
-export default function ProductInfoTabs({ active = 'features' }: ProductInfoTabsProps) {
+export default function ProductInfoTabs({ active, onChange }: ProductInfoTabsProps) {
   return (
     <nav aria-label="상품 상세 탭" className="rounded-lg bg-yg-white px-6 pt-4 shadow">
       <div className="flex gap-6 border-b border-yg-lightgray">
@@ -19,17 +20,13 @@ export default function ProductInfoTabs({ active = 'features' }: ProductInfoTabs
           const isActive = tab.key === active;
 
           return (
-            <button key={tab.key} type="button" className={['relative pb-3 text-sm font-semibold transition', isActive ? 'text-yg-primary' : 'text-yg-gray hover:text-yg-darkgray'].join(' ')}>
+            <button key={tab.key} type="button" onClick={() => onChange(tab.key)} className={['relative pb-3 text-sm font-semibold transition', isActive ? 'text-yg-primary' : 'text-yg-gray hover:text-yg-darkgray'].join(' ')}>
               {tab.label}
-
-              {/* active underline */}
               {isActive && <span className="absolute left-0 right-0 -bottom-[1px] h-[3px] rounded-full bg-yg-primary" />}
             </button>
           );
         })}
       </div>
-
-      {/* 아래 여백 (시안 느낌 맞추기) */}
       <div className="h-3" />
     </nav>
   );


### PR DESCRIPTION
## 연관 이슈

- #31 

## 반영 브랜치

- feature/product-detail-tabs-interaction -> develop
## 작업 사항

- [x] `page.tsx`에서 active 탭 상태 관리(useState)
- [x] `ProductInfoTabs`에 `active`, `onChange` props 추가
- [x] 섹션 별 id 부여 (features/nutrition/intake/cautions)
- [x] 탭 클릭 시 해당 id로 스크롤 이동

