### PR TITLE
fix: ProductSidePurchaseCard 삭제 및 레이아웃 단일 컬럼

### DIFF
--- a/app/products/[_id]/page.tsx
+++ b/app/products/[_id]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import ProductSidePurchaseCard from '@/components/products/ProductSidePurchaseCard';
 import ProductInfoSection from '@/components/products/ProductInfoSection';
 import ProductInfoTabs from '@/components/products/ProductInfoTabs';
 import ProductSummary from '@/components/products/ProductSummary';
@@ -24,21 +23,17 @@ export default function ProductDetailPage() {
   };
 
   return (
-    <main className="mx-auto max-w-7xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold text-yg-black">{product.name}</h1>
+    <main className="mx-auto max-w-5xl px-4 py-8 space-y-6">
+      {/* ✅ 정보 페이지: 우측 카드 없음, 단일 컬럼 */}
+      <ProductSummary name={product.name} summary={product.summary} brand={product.brand} rating={product.rating} reviewCount={product.reviewCount} imageUrl={product.imageUrl} tags={product.tags} />
 
-      <section className="grid grid-cols-12 gap-6">
-        <div className="col-span-8 space-y-6">
-          <ProductSummary name={product.name} summary={product.summary} price={product.price} brand={product.brand} rating={product.rating} reviewCount={product.reviewCount} shippingLabel={product.shippingLabel} imageUrl={product.imageUrl} tags={product.tags} />
+      {/* ✅ 탭: 스크롤 내려도 항상 보이게 */}
+      <div className="sticky top-16 z-20">
+        <ProductInfoTabs active={activeTab} onChange={handleChangeTab} />
+      </div>
 
-          {/* ✅ 탭 클릭 로직 연결 */}
-          <ProductInfoTabs active={activeTab} onChange={handleChangeTab} />
-
-          <ProductInfoSection features={product.features} nutritionFacts={product.nutritionFacts} intake={product.intake} cautions={product.cautions} />
-        </div>
-
-        <ProductSidePurchaseCard price={product.price} shippingLabel={product.shippingLabel} />
-      </section>
+      {/* ✅ 상세 섹션 */}
+      <ProductInfoSection features={product.features} nutritionFacts={product.nutritionFacts} intake={product.intake} cautions={product.cautions} />
     </main>
   );
 }

--- a/components/products/ProductSummary.tsx
+++ b/components/products/ProductSummary.tsx
@@ -1,37 +1,24 @@
 type ProductSummaryProps = {
   name: string;
   summary: string;
-  price: number;
   brand?: string;
   rating?: number;
   reviewCount?: number;
-  shippingLabel?: string;
   imageUrl?: string;
   tags?: string[];
 };
 
-export default function ProductSummary({ name, summary, price, brand, rating, reviewCount, shippingLabel, imageUrl, tags }: ProductSummaryProps) {
+export default function ProductSummary({ name, summary, brand, rating, reviewCount, imageUrl, tags }: ProductSummaryProps) {
   return (
     <section className="rounded-lg bg-yg-white p-6 shadow">
       <div className="grid grid-cols-12 gap-6">
-        {/* 이미지 영역 */}
+        {/* 이미지 */}
         <div className="col-span-5">
-          <div className="aspect-square w-full overflow-hidden rounded-lg bg-yg-lightgray">
-            {/* next/image 붙이기 전까지는 img로 */}
-            {imageUrl ? <img src={imageUrl} alt={name} className="h-full w-full object-cover" /> : <div className="flex h-full w-full items-center justify-center text-yg-darkgray">이미지 없음</div>}
-          </div>
-
-          {/* 썸네일(선택) 자리 */}
-          <div className="mt-3 flex gap-2">
-            <div className="h-14 w-14 rounded-md bg-yg-lightgray" />
-            <div className="h-14 w-14 rounded-md bg-yg-lightgray" />
-            <div className="h-14 w-14 rounded-md bg-yg-lightgray" />
-          </div>
+          <div className="aspect-square w-full overflow-hidden rounded-lg bg-yg-lightgray">{imageUrl ? <img src={imageUrl} alt={name} className="h-full w-full object-cover" /> : <div className="flex h-full w-full items-center justify-center text-yg-darkgray">이미지 없음</div>}</div>
         </div>
 
-        {/* 텍스트/버튼 영역 */}
-        <div className="col-span-7 flex flex-col">
-          {/* 태그/브랜드 */}
+        {/* 텍스트 */}
+        <div className="col-span-7">
           <div className="mb-2 flex flex-wrap items-center gap-2">
             {tags?.map((t) => (
               <span key={t} className="rounded-full bg-yg-secondary px-2 py-1 text-xs font-semibold text-yg-black">
@@ -41,34 +28,15 @@ export default function ProductSummary({ name, summary, price, brand, rating, re
             {brand && <span className="text-sm font-medium text-yg-darkgray">{brand}</span>}
           </div>
 
-          {/* 상품명 */}
           <h1 className="text-2xl font-bold text-yg-black">{name}</h1>
-
-          {/* 요약 */}
           <p className="mt-2 text-sm leading-6 text-yg-darkgray">{summary}</p>
 
-          {/* 평점/리뷰 */}
-          {(rating || reviewCount) && (
+          {(rating !== undefined || reviewCount !== undefined) && (
             <div className="mt-3 flex items-center gap-2 text-sm">
               {rating !== undefined && <span className="font-semibold text-yg-black">★ {rating}</span>}
               {reviewCount !== undefined && <span className="text-yg-darkgray">리뷰 {reviewCount.toLocaleString()}</span>}
             </div>
           )}
-
-          {/* 가격 */}
-          <div className="mt-4">
-            <p className="text-sm text-yg-darkgray">판매가</p>
-            <p className="text-3xl font-extrabold text-yg-black">{price.toLocaleString()}원</p>
-          </div>
-
-          {/* 배송 */}
-          {shippingLabel && <p className="mt-2 text-sm text-yg-darkgray">{shippingLabel}</p>}
-
-          {/* 버튼 */}
-          <div className="mt-auto flex gap-3 pt-6">
-            <button className="flex-1 rounded-md bg-yg-primary py-3 font-semibold text-white">구매하기</button>
-            <button className="flex-1 rounded-md border border-yg-lightgray bg-white py-3 font-semibold text-yg-black">장바구니</button>
-          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 연관 이슈

- #34 

## 반영 브랜치

- fix/productsidepurchasecard -> develop (예제 삭제)

## 작업 사항

- [x] Product purchase card 삭제
- [x] 레이아웃 단일로 수정
- [x] 탭 sticky

## 전달 사항 (없으면 삭제)

마크업 완료했습니다. 추가 사항 있으시면 말씀해주세요.
