### PR TITLE
feat: 설문 결과 페이지 payload 가드 및 API 연동

### DIFF
--- a/app/survey/result/SurveyResultClient.tsx
+++ b/app/survey/result/SurveyResultClient.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
+
+import { getProducts } from '@/lib/api/products';
+import type { SupplementItem } from '@/types/product';
+import type { SurveyResultPayload } from '@/types/survey';
+import { SURVEY_RESULT_PAYLOAD_KEY } from '@/app/survey/constants/storage';
+
+import ResultShell from '@/components/survey/result/ResultShell';
+import ConditionSummaryCard from '@/components/survey/result/ConditionSummaryCard';
+import SupplementCard, { type Supplement } from '@/components/survey/result/SupplementCard';
+import AiQuestion from '@/components/survey/result/AiQuestion';
+import SubscribeButton from '@/components/survey/result/SubscribeButton';
+
+const MAX_RECOMMEND_COUNT = 3;
+const RECOMMENDED_PRODUCTS_KEY = 'recommendedProducts';
+
+// 임시 요약
+const TEMP_SUMMARY = '설문 결과를 기반으로 카테고리별 추천 영양제를 준비했어요.';
+
+function saveRecommendedProducts(supplements: Supplement[]) {
+  const recommendedProducts = supplements.map((item) => ({
+    id: item.id,
+    name: item.name,
+    price: item.price,
+    description: item.description,
+  }));
+
+  sessionStorage.setItem(RECOMMENDED_PRODUCTS_KEY, JSON.stringify(recommendedProducts));
+}
+
+// SupplementItem → Supplement 변환
+function mapToSupplement(item: SupplementItem): Supplement {
+  return {
+    id: String(item._id),
+    name: item.name,
+    price: item.price,
+    description: (item.mainFunctions ?? []).join(', '),
+    tags: (item.mainNutrients ?? []).slice(0, 2).map((n) => ({ label: n })),
+    badge: '추천',
+    imageUrl: item.imageUrl,
+  };
+}
+
+//선택한 카테고리 개수에 따라 추천 개수 결정
+function getRecommendCount(selectedCategories: unknown): number {
+  const n = Array.isArray(selectedCategories) ? selectedCategories.length : 0;
+  if (n <= 0) return 0;
+  if (n === 1) return 2;
+  return 3;
+}
+
+export default function SurveyResultPage() {
+  const router = useRouter();
+
+  const [payload, setPayload] = useState<SurveyResultPayload | null | undefined>(undefined);
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      const raw = sessionStorage.getItem(SURVEY_RESULT_PAYLOAD_KEY);
+
+      if (!raw) {
+        setPayload(null);
+        return;
+      }
+
+      try {
+        setPayload(JSON.parse(raw) as SurveyResultPayload);
+      } catch {
+        setPayload(null);
+      }
+    });
+  }, []);
+
+  // payload 가드: 읽기 완료 후(null)면 리다이렉트
+  useEffect(() => {
+    if (payload === null) router.replace('/survey');
+  }, [payload, router]);
+
+  // 추천 개수
+  const recommendCount = payload ? getRecommendCount(payload.selectedCategories) : 0;
+
+  // 상품 API 호출: payload가 있을 때만
+  const {
+    data: products,
+    error,
+    isLoading,
+    mutate,
+  } = useSWR<SupplementItem[]>(
+    payload ? 'products' : null,
+    async () => {
+      const res = await getProducts();
+      if (res.ok !== 1 || !res.item) throw new Error('Failed to fetch products');
+      return res.item;
+    },
+    { revalidateOnFocus: false }
+  );
+
+  const isError = Boolean(error);
+
+  // 카테고리 기반 후보
+  const supplements: Supplement[] = useMemo(() => {
+    if (!payload || !products) return [];
+
+    const selected = Array.isArray(payload.selectedCategories) ? payload.selectedCategories : [];
+    const selectedSet = new Set(selected.map(String));
+
+    const count = Math.min(recommendCount, MAX_RECOMMEND_COUNT);
+    if (count === 0) return [];
+
+    const filtered = products.filter((p) => p.categoryId && selectedSet.has(String(p.categoryId)));
+    return filtered.slice(0, count).map(mapToSupplement);
+  }, [payload, products, recommendCount]);
+
+  const handleSubscribe = () => {
+    if (supplements.length === 0) return;
+    saveRecommendedProducts(supplements);
+    router.push('/subscription');
+  };
+
+  const handleClickDetail = (id: string) => {
+    router.push(`/products/${id}`);
+  };
+
+  // hydration mismatch 방지
+  if (payload === undefined) return null;
+
+  // payload 없으면 redirect 중이므로 렌더 막기
+  if (payload === null) return null;
+
+  return (
+    <>
+      <ResultShell title="AI 영양제 추천 결과">
+        <ConditionSummaryCard summary={TEMP_SUMMARY} isLoading={isLoading} isError={isError} />
+
+        <section className="mb-10">
+          <div className="mb-4">
+            <h2 className="text-3xl font-bold text-yg-black">추천 영양제</h2>
+            <p className="mt-1 text-sm font-normal text-yg-darkgray">AI가 분석한 맞춤 영양제 {Math.min(recommendCount, MAX_RECOMMEND_COUNT)}가지</p>
+          </div>
+
+          {/* 로딩 */}
+          {isLoading && <div className="rounded-2xl border border-yg-lightgray bg-white p-6 text-sm text-yg-darkgray shadow-sm">추천 영양제를 불러오는 중이에요...</div>}
+
+          {/* 에러 */}
+          {!isLoading && isError && (
+            <div className="rounded-2xl border border-yg-lightgray bg-white p-6 shadow-sm">
+              <p className="text-sm text-yg-darkgray">추천 영양제를 불러오지 못했어요.</p>
+              <button type="button" onClick={() => mutate()} className="mt-4 rounded-xl border border-yg-lightgray bg-white px-4 py-2 text-sm font-semibold text-yg-black">
+                다시 시도
+              </button>
+            </div>
+          )}
+
+          {/* 정상 */}
+          {!isLoading && !isError && (
+            <>
+              {supplements.length === 0 ? (
+                <div className="rounded-2xl border border-yg-lightgray bg-white p-6 text-sm text-yg-darkgray shadow-sm">추천 조건을 충족하는 건강식품이 없어요.</div>
+              ) : (
+                <div className="space-y-6">
+                  {supplements.map((item) => (
+                    <SupplementCard key={item.id} item={item} onClickDetail={handleClickDetail} />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </section>
+
+        <AiQuestion />
+      </ResultShell>
+
+      <SubscribeButton onClick={handleSubscribe} />
+    </>
+  );
+}

--- a/app/survey/result/page.tsx
+++ b/app/survey/result/page.tsx
@@ -1,78 +1,11 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
 
-import ResultShell from '@/components/survey/result/ResultShell';
-import ConditionSummaryCard from '@/components/survey/result/ConditionSummaryCard';
-import SupplementCard, { type Supplement } from '@/components/survey/result/SupplementCard';
-import AiQuestion from '@/components/survey/result/AiQuestion';
-import SubscribeButton from '@/components/survey/result/SubscribeButton';
+const SurveyResultClient = dynamic(() => import('./SurveyResultClient'), {
+  ssr: false,
+});
 
-import { MOCK_SUMMARY, MOCK_SUPPLEMENTS } from '../../../mock/result.mock';
-
-const MAX_RECOMMEND_COUNT = 3;
-const RECOMMENDED_PRODUCTS_KEY = 'recommendedProducts';
-
-function saveRecommendedProducts(supplements: Supplement[]) {
-  const recommendedProducts = supplements.map((item) => ({
-    id: item.id,
-    name: item.name,
-    price: item.price,
-    description: item.description,
-  }));
-
-  sessionStorage.setItem(RECOMMENDED_PRODUCTS_KEY, JSON.stringify(recommendedProducts));
-}
-
-export default function SurveyResultPage() {
-  const router = useRouter();
-
-  // fetch 붙이면 useState로 교체
-  const isLoading = false;
-  const isError = false;
-
-  const summary = MOCK_SUMMARY;
-  const supplements = MOCK_SUPPLEMENTS;
-
-  const handleSubscribe = () => {
-    saveRecommendedProducts(supplements);
-    router.push('/subscription');
-  };
-
-  const handleClickDetail = (id: string) => {
-    router.push(`/products/${id}`);
-  };
-
-  const visibleSupplements = supplements.slice(0, MAX_RECOMMEND_COUNT);
-
-  return (
-    <>
-      {/* 상단 */}
-      <ResultShell title="AI 영양제 추천 결과">
-        {/* 설문 요약 */}
-        <ConditionSummaryCard summary={summary} isLoading={isLoading} isError={isError} />
-        {/* 추천 영양제 리스트 */}
-        <section className="mb-10">
-          <div className="mb-4">
-            <h2 className="text-3xl font-bold text-yg-black">추천 영양제</h2>
-            <p className="mt-1 text-sm font-normal text-yg-darkgray">AI가 분석한 맞춤 영양제 {MAX_RECOMMEND_COUNT}가지</p>
-          </div>
-
-          {visibleSupplements.length === 0 ? (
-            <div className="rounded-2xl border border-yg-lightgray bg-white p-6 text-sm text-yg-darkgray shadow-sm">추천 조건을 충족하는 건강식품이 없어요.</div>
-          ) : (
-            <div className="space-y-6">
-              {visibleSupplements.map((item) => (
-                <SupplementCard key={item.id} item={item} onClickDetail={handleClickDetail} />
-              ))}
-            </div>
-          )}
-        </section>
-        {/* AI질문 */}
-        <AiQuestion />
-      </ResultShell>
-      {/* 구독하기 */}
-      <SubscribeButton onClick={handleSubscribe} />
-    </>
-  );
+export default function Page() {
+  return <SurveyResultClient />;
 }

--- a/components/survey/result/SupplementCard.tsx
+++ b/components/survey/result/SupplementCard.tsx
@@ -1,4 +1,5 @@
 'use client';
+import Image from 'next/image';
 
 export type SupplementTag = { label: string };
 
@@ -9,8 +10,8 @@ export type Supplement = {
   description: string;
   tags: SupplementTag[];
   badge?: string;
+  imageUrl?: string;
 };
-
 type Props = {
   item: Supplement;
   onClickDetail?: (id: string) => void;
@@ -20,13 +21,13 @@ export default function SupplementCard({ item, onClickDetail }: Props) {
   return (
     <article className="overflow-hidden rounded-2xl border border-yg-lightgray bg-white shadow-sm">
       {/* 이미지 영역 */}
-      <div className="relative h-52 w-full bg-yg-white">
-        <div className="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full border border-yg-lightgray bg-white px-3 py-1 text-xs font-semibold text-yg-black">
+      <div className="relative h-52 w-full overflow-hidden bg-yg-white">
+        <div className="absolute left-4 top-4 z-10 inline-flex items-center gap-2 rounded-full border border-yg-lightgray bg-white px-3 py-1 text-xs font-semibold text-yg-black">
           <span className="h-2 w-2 rounded-full bg-yg-primary" />
           {item.badge ?? 'AI 추천'}
         </div>
-        {/* 현재는 실제 상품 이미지가 없어 아이콘 사용 */}
-        <div className="flex h-full items-center justify-center text-5xl">💊</div>
+
+        {item.imageUrl ? <Image src={item.imageUrl} alt={item.name} fill className="object-cover" sizes="(max-width: 1024px) 100vw, 50vw" /> : <div className="flex h-full items-center justify-center text-5xl">💊</div>}
       </div>
 
       <div className="p-6">

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-spinners": "^0.17.0",
+        "swr": "^2.4.0",
         "tailwind-merge": "^3.4.0",
         "zustand": "^5.0.11"
       },
@@ -2809,6 +2810,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -6208,6 +6218,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.0.tgz",
+      "integrity": "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -6586,6 +6609,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-spinners": "^0.17.0",
+    "swr": "^2.4.0",
     "tailwind-merge": "^3.4.0",
     "zustand": "^5.0.11"
   },

--- a/types/survey.ts
+++ b/types/survey.ts
@@ -43,7 +43,7 @@ export type SurveyResultPayload = {
     ageGroup: string;
   };
 
-  selectedCategories: CategoryKey[];
+  selectedCategories: string[];
 
   categories: Record<
     CategoryKey,


### PR DESCRIPTION
## 연관 이슈

- #79 
## 반영 브랜치

- feature/survey-result-products

## 작업 사항

- [x] /survey/result 진입 시 sessionStorage에서 설문 결과 payload 로드
- [x] payload가 없을 경우 설문 시작 페이지로 리다이렉트
- [x] 상품 목록 API 호출
- [x] 설문에서 선택한 카테고리 기준으로 상품 후보 필터링
- [x] 결과 페이지 데이터 기반 추천 상품 렌더링
- [x] 로딩 / 에러 / 빈 결과 UI 처리

## 전달 사항 (없으면 삭제)

- swr 라이브러리 추가하였으니 PR 머지 후  pull 받으시고 npm i 부탁드립니다!
