### PR TITLE
fix: 설문 정보 상세 페이지 기능 보완

### DIFF
--- a/app/survey/history/[id]/page.tsx
+++ b/app/survey/history/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { getSurveyByIdFromServer, type SurveyHistoryItem } from '@/lib/api/survey';
 
@@ -8,8 +8,22 @@ import ResultShell from '@/components/survey/result/ResultShell';
 import ConditionSummaryCard from '@/components/survey/result/ConditionSummaryCard';
 import SupplementCard, { type Supplement } from '@/components/survey/result/SupplementCard';
 import AiQuestion from '@/components/survey/result/AiQuestion';
+import SubscribeButton from '@/components/survey/result/SubscribeButton';
 
-const TEMP_SUMMARY = '설문 결과를 기반으로 카테고리별 추천 영양제를 준비했어요.';
+const FALLBACK_SUMMARY = '설문 결과를 기반으로 카테고리별 추천 영양제를 준비했어요.';
+const RECOMMENDED_PRODUCTS_KEY = 'recommendedProducts';
+
+function saveRecommendedProducts(supplements: Supplement[]) {
+  const recommendedProducts = supplements.map((item) => ({
+    id: item.id,
+    name: item.name,
+    price: item.price,
+    description: item.description,
+    imageUrl: item.imageUrl,
+  }));
+
+  sessionStorage.setItem(RECOMMENDED_PRODUCTS_KEY, JSON.stringify(recommendedProducts));
+}
 
 export default function SurveyHistoryDetailPage() {
   const router = useRouter();
@@ -50,28 +64,31 @@ export default function SurveyHistoryDetailPage() {
     router.push('/mypage');
   };
 
-  const supplements: Supplement[] = useMemo(() => {
-    if (!historyData) return [];
+  const handleSubscribe = () => {
+    if (!historyData || supplements.length === 0) return;
+    saveRecommendedProducts(supplements);
+    router.push('/subscription');
+  };
 
-    return historyData.memo.supplements.map((item) => ({
-      id: item.id,
-      name: item.name,
-      price: item.price,
-      description: item.description,
-      tags: [],
-      badge: '추천',
-      imageUrl: item.imageUrl,
-    }));
-  }, [historyData]);
+  const supplements: Supplement[] = !historyData
+    ? []
+    : historyData.memo.supplements.map((item) => ({
+        id: item.id,
+        name: item.name,
+        price: item.price,
+        description: item.description,
+        tags: [],
+        badge: '추천',
+        imageUrl: item.imageUrl,
+      }));
 
-  const top3Products = useMemo(
-    () =>
-      supplements.slice(0, 3).map((s) => ({
-        name: s.name,
-        description: s.description,
-      })),
-    [supplements]
-  );
+  const top3Products = supplements.slice(0, 3).map((s) => ({
+    name: s.name,
+    description: s.description,
+  }));
+
+  // summary 가져오기
+  const summaryText = historyData?.memo.summary || FALLBACK_SUMMARY;
 
   if (isLoading || !historyData) {
     return (
@@ -96,7 +113,7 @@ export default function SurveyHistoryDetailPage() {
           </button>
         </div>
 
-        <ConditionSummaryCard summary={TEMP_SUMMARY} />
+        <ConditionSummaryCard summary={summaryText} />
 
         <section className="mb-10">
           <div className="mb-4">
@@ -115,8 +132,13 @@ export default function SurveyHistoryDetailPage() {
           )}
         </section>
 
-        <AiQuestion payloadSummary={TEMP_SUMMARY} top3Products={top3Products} />
+        <AiQuestion payloadSummary={summaryText} top3Products={top3Products} />
       </ResultShell>
+
+      {/* 구독하기 버튼 추가 */}
+      {supplements.length > 0 && (
+        <SubscribeButton onClick={handleSubscribe} />
+      )}
     </>
   );
 }

--- a/app/survey/result/SurveyResultClient.tsx
+++ b/app/survey/result/SurveyResultClient.tsx
@@ -240,16 +240,32 @@ export default function SurveyResultPage() {
     [finalSupplements]
   );
 
+  const summaryText = useMemo(() => {
+    if (aiError) return '답변을 생성하는 데 문제가 발생했어요. 잠시 후 다시 시도해주세요.';
+    return aiData?.summary ?? FALLBACK_SUMMARY;
+  }, [aiError, aiData]);
+
   // 설문 기록 저장 (finalSupplements가 로드되면 자동 저장)
   useEffect(() => {
     if (!finalSupplements.length || !payload || !user) return;
 
-    const currentSurveyId = JSON.stringify(payload);
+    // AI 로딩 중이면 대기
+    if (isAiLoading) {
+      console.log('⏳ AI 응답 대기 중... (로딩)');
+      return;
+    }
 
+    // AI 데이터가 없고 에러도 없으면 아직 완료 안 됨
+    if (!aiData && !aiError) {
+      console.log('⏳ AI 응답 대기 중... (데이터 없음)');
+      return;
+    }
+
+    const currentSurveyId = JSON.stringify(payload);
     const savedSurveyId = localStorage.getItem('lastSavedSurveyId');
 
     if (!hasSavedHistoryRef.current && savedSurveyId !== currentSurveyId) {
-      saveSurveyToServer(payload, finalSupplements)
+      saveSurveyToServer(payload, finalSupplements, summaryText)
         .then((result) => {
           if (result.ok === 1) {
             localStorage.setItem('lastSavedSurveyId', currentSurveyId);
@@ -258,9 +274,7 @@ export default function SurveyResultPage() {
         .catch(() => {});
       hasSavedHistoryRef.current = true;
     }
-  }, [finalSupplements, payload, user]);
-
-  const summaryText = aiError ? '답변을 생성하는 데 문제가 발생했어요. 잠시 후 다시 시도해주세요.' : (aiData?.summary ?? FALLBACK_SUMMARY);
+  }, [finalSupplements, payload, user, summaryText, aiData, aiError, isAiLoading]); 
 
   const handleSubscribe = () => {
     if (finalSupplements.length === 0) return;

--- a/lib/api/survey.ts
+++ b/lib/api/survey.ts
@@ -44,6 +44,7 @@ interface SurveyContent {
     description: string;
     imageUrl?: string;
   }>;
+  summary?: string;
 }
 
 export interface SurveyHistoryItem {
@@ -62,6 +63,7 @@ export interface SurveyHistoryItem {
       description: string;
       imageUrl?: string;
     }>;
+    summary?: string;
   };
   createdAt: string;
   updatedAt: string;
@@ -76,7 +78,8 @@ export async function saveSurveyToServer(
     price: number;
     description: string;
     imageUrl?: string;
-  }>
+  }>,
+  summary?: string
 ): Promise<{ ok: 0 | 1; message?: string; item?: SurveyHistoryItem }> {
   try {
     const cookieStore = await cookies();
@@ -100,6 +103,7 @@ export async function saveSurveyToServer(
         date: new Date().toISOString().split('T')[0].replace(/-/g, '.'),
         payload,
         supplements,
+        summary,
       }),
     };
 
@@ -167,6 +171,7 @@ export async function saveSurveyToServer(
           date: new Date().toISOString().split('T')[0].replace(/-/g, '.'),
           payload,
           supplements,
+          summary,
         },
         createdAt: postResult.item.createdAt,
         updatedAt: postResult.item.updatedAt,
@@ -227,6 +232,7 @@ export async function getSurveysFromServer(): Promise<{
           date: content.date,
           payload: content.payload,
           supplements: content.supplements,
+          summary: content.summary,
         },
         createdAt: post.createdAt,
         updatedAt: post.updatedAt,
@@ -287,6 +293,7 @@ export async function getSurveyByIdFromServer(
         date: content.date,
         payload: content.payload,
         supplements: content.supplements,
+        summary: content.summary,
       },
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,


### PR DESCRIPTION
## 연관 이슈

- #109 

## 반영 브랜치

- feature/mypage -> develop

## 작업 사항

- [x] AI 요약 저장 기능 구현
- [x] 설문 정보 상세 페이지에서 결제/구독 페이지로 이동

## 전달 사항

- SurveyResultClient.tsx가 수정되었습니다(AI 요약 저장 기능 구현)!
